### PR TITLE
Update Dockerfile to use v1.0.0 release checkpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,11 @@ RUN git clone https://github.com/aqlaboratory/genie2.git \
 
 WORKDIR /app/genie2/
 
-## Install the base checkpoint
-RUN cd results/base \
-    && git lfs pull
+## Download the base checkpoint (from v1.0.0 release)
+RUN mkdir results/base/checkpoints \
+    && cd results/base/checkpoints \
+    # && git lfs pull
+    # && wget https://github.com/aqlaboratory/genie2/releases/download/v1.0.0/epoch.30.ckpt \
+    && wget https://github.com/aqlaboratory/genie2/releases/download/v1.0.0/epoch.40.ckpt \
+    ## Hack to make the checkpoint loadable
+    && ln -s epoch.40.ckpt epoch=40.ckpt


### PR DESCRIPTION
This minor update to the Dockerfile automatically pulls with epoch 40 checkpoint from the v1.0.0 release.

Note that there is a small bug in how the `sample_unconditional.py` script assembles the path to the check point.

This command:
```bash
python genie/sample_unconditional.py --name base --epoch 40 --scale 0.6 --outdir results/base/outputs
```

...should point to `results/base/checkpoints/epoch.40.ckpt`, but instead looks for `results/base/checkpoints/epoch=40.ckpt`.
There is a temporary symbolic link in this Dockerfile that can be removed later when this bug is fixed.